### PR TITLE
feat: Document Upload Flow (#21)

### DIFF
--- a/apps/keystona/ios/Runner/Info.plist
+++ b/apps/keystona/ios/Runner/Info.plist
@@ -41,6 +41,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Keystona needs access to your photo library to add images as documents.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Keystona needs camera access to photograph documents.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Keystona needs microphone access when using the camera.</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/apps/keystona/lib/core/router/app_router.dart
+++ b/apps/keystona/lib/core/router/app_router.dart
@@ -5,6 +5,7 @@ import '../../features/auth/providers/auth_provider.dart';
 import '../../features/auth/screens/forgot_password_screen.dart';
 import '../../features/auth/screens/login_screen.dart';
 import '../../features/auth/screens/signup_screen.dart';
+import '../../features/documents/screens/document_upload_screen.dart';
 import '../../features/documents/screens/documents_screen.dart';
 import '../../features/onboarding/screens/property_setup_screen.dart';
 import '../../features/onboarding/screens/trial_screen.dart';
@@ -249,8 +250,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                   // Static segments must precede parameterised ':documentId'.
                   GoRoute(
                     path: 'upload',
-                    builder: (_, _) =>
-                        const PlaceholderScreen(name: 'Upload Document'),
+                    builder: (_, _) => const DocumentUploadScreen(),
                   ),
                   GoRoute(
                     path: 'search',

--- a/apps/keystona/lib/features/documents/models/document_upload_state.dart
+++ b/apps/keystona/lib/features/documents/models/document_upload_state.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'document.dart';
+
+part 'document_upload_state.freezed.dart';
+
+/// The step the upload wizard is currently showing.
+enum DocumentUploadStep {
+  /// Step 1 — user selects a category (and optionally a document type).
+  category,
+
+  /// Step 2 — user enters name, expiration date, and notes.
+  metadata,
+
+  /// Step 3 — upload in progress; transitions to [success] or shows error.
+  uploading,
+
+  /// Upload finished — shows confirmation card with "View Document" option.
+  success,
+}
+
+/// Ephemeral wizard state for the document upload flow.
+///
+/// Not serialised — kept in-memory only.
+@freezed
+abstract class DocumentUploadState with _$DocumentUploadState {
+  const factory DocumentUploadState({
+    /// Which step the wizard is showing.
+    @Default(DocumentUploadStep.category) DocumentUploadStep step,
+
+    /// The file the user has picked. Null only during source-picker display.
+    File? file,
+
+    /// MIME type inferred from the file extension.
+    String? mimeType,
+
+    /// File name without extension — pre-filled into the name field.
+    @Default('') String suggestedName,
+
+    // ── Step 1 fields ────────────────────────────────────────────────────────
+
+    /// Selected category ID. Required before advancing to step 2.
+    String? categoryId,
+
+    /// Optional document type ID within the category.
+    String? documentTypeId,
+
+    // ── Step 2 fields ────────────────────────────────────────────────────────
+
+    /// Document name. Required. Auto-filled from [suggestedName].
+    @Default('') String name,
+
+    /// Optional expiration date. Used for expiration badges.
+    DateTime? expirationDate,
+
+    /// Optional freeform notes.
+    String? notes,
+
+    // ── Step 3 fields ────────────────────────────────────────────────────────
+
+    /// Upload progress 0.0–1.0.
+    @Default(0.0) double uploadProgress,
+
+    /// Set after a successful upload. Used to build the success card.
+    Document? uploadedDocument,
+
+    /// Set when an upload error occurs.
+    String? errorMessage,
+  }) = _DocumentUploadState;
+}

--- a/apps/keystona/lib/features/documents/providers/document_types_provider.dart
+++ b/apps/keystona/lib/features/documents/providers/document_types_provider.dart
@@ -1,0 +1,24 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../services/supabase_service.dart';
+import '../models/document_type.dart';
+
+part 'document_types_provider.g.dart';
+
+/// Loads all document types that belong to [categoryId], sorted by [sortOrder].
+///
+/// Used by the upload wizard category step to show type sub-selection after
+/// the user picks a category.
+@riverpod
+Future<List<DocumentType>> documentTypes(
+  Ref ref,
+  String categoryId,
+) async {
+  final response = await SupabaseService.client
+      .from('document_types')
+      .select('id, category_id, name, description, metadata_schema, sort_order')
+      .eq('category_id', categoryId)
+      .order('sort_order');
+
+  return response.map((json) => DocumentType.fromJson(json)).toList();
+}

--- a/apps/keystona/lib/features/documents/providers/document_upload_provider.dart
+++ b/apps/keystona/lib/features/documents/providers/document_upload_provider.dart
@@ -1,0 +1,260 @@
+import 'dart:io';
+
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show FileOptions;
+import 'package:uuid/uuid.dart';
+
+import '../../../services/supabase_service.dart';
+import '../models/document.dart';
+import '../models/document_upload_state.dart';
+import 'documents_provider.dart';
+
+part 'document_upload_provider.g.dart';
+
+const _freeDocumentLimit = 25;
+
+/// Manages the document upload wizard state and the actual upload operation.
+///
+/// Lifecycle: created when the upload screen opens, disposed on pop.
+/// The [DocumentsNotifier] list is invalidated after a successful upload.
+///
+/// Step flow:
+///   category → metadata → uploading → success
+@riverpod
+class DocumentUploadNotifier extends _$DocumentUploadNotifier {
+  @override
+  DocumentUploadState build() => const DocumentUploadState();
+
+  // ── File ─────────────────────────────────────────────────────────────────
+
+  /// Called from the upload screen after the user picks a file.
+  ///
+  /// Stores the file and derived metadata, then starts at [DocumentUploadStep.category].
+  void setFile(File file, String mimeType, String suggestedName) {
+    state = DocumentUploadState(
+      file: file,
+      mimeType: mimeType,
+      suggestedName: suggestedName,
+      name: suggestedName,
+    );
+  }
+
+  // ── Step 1 ───────────────────────────────────────────────────────────────
+
+  /// Stores the selected category and advances to metadata step.
+  void selectCategory(String categoryId, {String? documentTypeId}) {
+    state = state.copyWith(
+      categoryId: categoryId,
+      documentTypeId: documentTypeId,
+    );
+  }
+
+  void advanceToMetadata() {
+    state = state.copyWith(step: DocumentUploadStep.metadata);
+  }
+
+  // ── Step 2 ───────────────────────────────────────────────────────────────
+
+  void setName(String value) => state = state.copyWith(name: value);
+  void setExpirationDate(DateTime? value) =>
+      state = state.copyWith(expirationDate: value);
+  void setNotes(String? value) => state = state.copyWith(notes: value);
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+
+  void goBack() {
+    switch (state.step) {
+      case DocumentUploadStep.metadata:
+        state = state.copyWith(step: DocumentUploadStep.category);
+      case DocumentUploadStep.uploading:
+      case DocumentUploadStep.success:
+      case DocumentUploadStep.category:
+        break;
+    }
+  }
+
+  // ── Upload ───────────────────────────────────────────────────────────────
+
+  /// Validates metadata, checks the free tier limit, then uploads the file.
+  ///
+  /// On success, invalidates [DocumentsNotifier] so the list refreshes.
+  /// On failure, sets [DocumentUploadState.errorMessage] and stays on the
+  /// progress step so the user can retry.
+  Future<void> upload() async {
+    final file = state.file;
+    if (file == null) return;
+
+    state = state.copyWith(
+      step: DocumentUploadStep.uploading,
+      errorMessage: null,
+      uploadProgress: 0.0,
+    );
+
+    try {
+      final client = SupabaseService.client;
+      final user = client.auth.currentUser;
+      if (user == null) throw Exception('Not signed in');
+
+      // ── 1. Resolve property ──────────────────────────────────────────────
+      state = state.copyWith(uploadProgress: 0.05);
+      final propertyRow = await client
+          .from('properties')
+          .select('id')
+          .eq('user_id', user.id)
+          .isFilter('deleted_at', null)
+          .order('created_at', ascending: false)
+          .limit(1)
+          .maybeSingle();
+
+      if (propertyRow == null) throw Exception('No property found');
+      final propertyId = propertyRow['id'] as String;
+
+      // ── 2. Free-tier gate ─────────────────────────────────────────────────
+      state = state.copyWith(uploadProgress: 0.1);
+      final countResponse = await client
+          .from('documents')
+          .select('id')
+          .eq('property_id', propertyId)
+          .isFilter('deleted_at', null);
+
+      if (countResponse.length >= _freeDocumentLimit) {
+        throw _FreeTierException();
+      }
+
+      // ── 3. Compress image if needed ──────────────────────────────────────
+      state = state.copyWith(uploadProgress: 0.2);
+      final uploadFile = await _prepareFile(file, state.mimeType);
+
+      // ── 4. Upload to Supabase Storage ────────────────────────────────────
+      state = state.copyWith(uploadProgress: 0.4);
+      final ext = _extensionFromMime(state.mimeType);
+      final storagePath =
+          '${user.id}/$propertyId/${const Uuid().v4()}$ext';
+
+      final bytes = await uploadFile.readAsBytes();
+      await client.storage
+          .from('documents')
+          .uploadBinary(
+            storagePath,
+            bytes,
+            fileOptions: FileOptions(contentType: state.mimeType ?? 'application/octet-stream'),
+          );
+
+      // ── 5. Insert document row ────────────────────────────────────────────
+      state = state.copyWith(uploadProgress: 0.8);
+      final trimmedNotes =
+          state.notes?.trim().isEmpty == true ? null : state.notes?.trim();
+
+      final response = await client
+          .from('documents')
+          .insert({
+            'property_id': propertyId,
+            'user_id': user.id,
+            'name': state.name.trim(),
+            'category_id': state.categoryId,
+            'document_type_id': state.documentTypeId,
+            'file_path': storagePath,
+            'file_size_bytes': await file.length(),
+            'mime_type': state.mimeType,
+            'expiration_date': state.expirationDate?.toIso8601String(),
+            'notes': trimmedNotes,
+            'ocr_status': 'pending',
+          })
+          .select(
+            'id, name, category_id, document_type_id, created_at, updated_at, '
+            'expiration_date, thumbnail_path, file_path, file_size_bytes, '
+            'mime_type, page_count, ocr_status, notes, linked_system_id, '
+            'linked_appliance_id',
+          )
+          .single();
+
+      // ── 6. Trigger OCR (fire-and-forget) ─────────────────────────────────
+      _triggerOcr(response['id'] as String);
+
+      // ── 7. Success ────────────────────────────────────────────────────────
+      state = state.copyWith(uploadProgress: 1.0);
+
+      final doc = Document.fromJson({
+        ...response,
+        'user_id': user.id,
+        'property_id': propertyId,
+        'metadata': <String, dynamic>{},
+      });
+
+      state = state.copyWith(
+        step: DocumentUploadStep.success,
+        uploadedDocument: doc,
+      );
+
+      // Refresh the documents list.
+      ref.invalidate(documentsProvider);
+    } on _FreeTierException {
+      state = state.copyWith(
+        step: DocumentUploadStep.metadata,
+        errorMessage: 'free_tier',
+      );
+    } catch (_) {
+      state = state.copyWith(
+        step: DocumentUploadStep.uploading,
+        errorMessage: 'Upload failed. Please try again.',
+      );
+    }
+  }
+
+  /// Retries a failed upload. Resets progress and re-runs [upload].
+  Future<void> retryUpload() async {
+    state = state.copyWith(errorMessage: null, uploadProgress: 0.0);
+    await upload();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /// Compresses HEIC/JPEG images. Returns original file for PDFs.
+  Future<File> _prepareFile(File file, String? mimeType) async {
+    if (mimeType == null || mimeType.startsWith('application/')) return file;
+
+    final bytes = await file.length();
+    const maxBytes = 2 * 1024 * 1024; // 2 MB
+    if (bytes <= maxBytes) return file;
+
+    final dir = await getTemporaryDirectory();
+    final targetPath =
+        '${dir.path}/upload_${DateTime.now().millisecondsSinceEpoch}.jpg';
+
+    final xFile = await FlutterImageCompress.compressAndGetFile(
+      file.absolute.path,
+      targetPath,
+      quality: 80,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+
+    return xFile != null ? File(xFile.path) : file;
+  }
+
+  String _extensionFromMime(String? mime) {
+    switch (mime) {
+      case 'application/pdf':
+        return '.pdf';
+      case 'image/jpeg':
+        return '.jpg';
+      case 'image/png':
+        return '.png';
+      case 'image/heic':
+        return '.heic';
+      default:
+        return '';
+    }
+  }
+
+  /// Fire-and-forget OCR trigger via Supabase Edge Function.
+  void _triggerOcr(String documentId) {
+    SupabaseService.client.functions
+        .invoke('process-document-ocr', body: {'document_id': documentId})
+        .ignore();
+  }
+}
+
+class _FreeTierException implements Exception {}

--- a/apps/keystona/lib/features/documents/providers/documents_provider.dart
+++ b/apps/keystona/lib/features/documents/providers/documents_provider.dart
@@ -124,9 +124,18 @@ class DocumentsNotifier extends _$DocumentsNotifier {
     throw UnimplementedError('setSearchQuery() implemented by issue #23');
   }
 
-  /// Uploads and creates a new document. Implemented by issue #21.
-  Future<Document> add(Map<String, dynamic> data) {
-    throw UnimplementedError('add() implemented by issue #21');
+  /// Refreshes the list to include a newly uploaded document.
+  ///
+  /// [data] is unused — callers should call [refresh] directly or let the
+  /// [DocumentUploadNotifier] call `ref.invalidate(documentsNotifierProvider)`
+  /// after a successful upload.
+  Future<Document> add(Map<String, dynamic> data) async {
+    ref.invalidateSelf();
+    await future;
+    // Return the first document in the refreshed list (most recent upload).
+    final docs = state.value ?? [];
+    if (docs.isEmpty) throw StateError('No documents after add');
+    return docs.first;
   }
 
   /// Fetches a single document by ID. Implemented by issue #22.

--- a/apps/keystona/lib/features/documents/screens/document_upload_screen.dart
+++ b/apps/keystona/lib/features/documents/screens/document_upload_screen.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_sizes.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../models/document_upload_state.dart';
+import '../providers/document_upload_provider.dart';
+import '../widgets/upload_category_step.dart';
+import '../widgets/upload_metadata_step.dart';
+import '../widgets/upload_progress_step.dart';
+import '../widgets/upload_source_sheet.dart';
+
+/// Multi-step wizard for uploading a document to the vault.
+///
+/// Step flow:
+///   source picker → category → metadata → progress/success
+///
+/// The source picker opens automatically on first frame. If the user cancels,
+/// the screen pops back to the document list.
+class DocumentUploadScreen extends ConsumerStatefulWidget {
+  const DocumentUploadScreen({super.key});
+
+  @override
+  ConsumerState<DocumentUploadScreen> createState() =>
+      _DocumentUploadScreenState();
+}
+
+class _DocumentUploadScreenState
+    extends ConsumerState<DocumentUploadScreen> {
+  bool _sourcePickerShown = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _showSourcePicker();
+    });
+  }
+
+  Future<void> _showSourcePicker() async {
+    _sourcePickerShown = true;
+    bool filePicked = false;
+
+    await UploadSourceSheet.show(
+      context,
+      ref,
+      onFilePicked: () => filePicked = true,
+    );
+
+    // If no file was picked (user cancelled), pop back.
+    if (!filePicked && mounted) {
+      context.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(documentUploadProvider);
+
+    // Nothing to show until a file is selected.
+    if (state.file == null && !_sourcePickerShown) {
+      return const Scaffold(body: SizedBox.shrink());
+    }
+
+    final title = _titleForStep(state.step);
+    final canPop = state.step == DocumentUploadStep.category ||
+        state.step == DocumentUploadStep.metadata;
+
+    return PopScope(
+      canPop: canPop,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && !canPop) return;
+        if (state.step == DocumentUploadStep.metadata) {
+          ref.read(documentUploadProvider.notifier).goBack();
+        }
+      },
+      child: Platform.isIOS ? _IOSScaffold(
+        title: title,
+        step: state.step,
+        onBack: canPop ? _handleBack : null,
+        child: _stepContent(state),
+      ) : _MaterialScaffold(
+        title: title,
+        step: state.step,
+        onBack: canPop ? _handleBack : null,
+        child: _stepContent(state),
+      ),
+    );
+  }
+
+  Widget _stepContent(DocumentUploadState state) {
+    return switch (state.step) {
+      DocumentUploadStep.category => UploadCategoryStep(
+          onNext: () {},
+        ),
+      DocumentUploadStep.metadata => UploadMetadataStep(
+          onNext: () {},
+          onBack: _handleBack,
+        ),
+      DocumentUploadStep.uploading ||
+      DocumentUploadStep.success =>
+        UploadProgressStep(
+          onDone: () {
+            // Reset provider state before popping so the next upload starts fresh.
+            ref.invalidate(documentUploadProvider);
+            context.pop();
+          },
+          onRetry: () =>
+              ref.read(documentUploadProvider.notifier).retryUpload(),
+        ),
+    };
+  }
+
+  void _handleBack() {
+    final step = ref.read(documentUploadProvider).step;
+    if (step == DocumentUploadStep.metadata) {
+      ref.read(documentUploadProvider.notifier).goBack();
+    } else {
+      context.pop();
+    }
+  }
+
+  String _titleForStep(DocumentUploadStep step) {
+    switch (step) {
+      case DocumentUploadStep.category:
+        return 'Add Document';
+      case DocumentUploadStep.metadata:
+        return 'Document Details';
+      case DocumentUploadStep.uploading:
+        return 'Uploading';
+      case DocumentUploadStep.success:
+        return 'Saved';
+    }
+  }
+}
+
+// ── iOS scaffold ──────────────────────────────────────────────────────────────
+
+class _IOSScaffold extends StatelessWidget {
+  const _IOSScaffold({
+    required this.title,
+    required this.step,
+    required this.onBack,
+    required this.child,
+  });
+
+  final String title;
+  final DocumentUploadStep step;
+  final VoidCallback? onBack;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle: Text(title),
+        leading: onBack != null
+            ? CupertinoButton(
+                padding: EdgeInsets.zero,
+                onPressed: onBack,
+                child: const Icon(CupertinoIcons.back),
+              )
+            : const SizedBox.shrink(),
+        trailing: step == DocumentUploadStep.uploading ||
+                step == DocumentUploadStep.success
+            ? const SizedBox.shrink()
+            : CupertinoButton(
+                padding: EdgeInsets.zero,
+                onPressed: () => Navigator.of(context, rootNavigator: true)
+                    .maybePop(),
+                child: const Text('Cancel'),
+              ),
+      ),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.md,
+            AppSizes.md,
+            AppSizes.md,
+            AppSizes.lg,
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Material scaffold ──────────────────────────────────────────────────────────
+
+class _MaterialScaffold extends StatelessWidget {
+  const _MaterialScaffold({
+    required this.title,
+    required this.step,
+    required this.onBack,
+    required this.child,
+  });
+
+  final String title;
+  final DocumentUploadStep step;
+  final VoidCallback? onBack;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isTerminal = step == DocumentUploadStep.uploading ||
+        step == DocumentUploadStep.success;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title, style: AppTextStyles.h3),
+        leading: onBack != null
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: onBack,
+              )
+            : null,
+        actions: isTerminal
+            ? null
+            : [
+                TextButton(
+                  onPressed: () => context.pop(),
+                  child: Text(
+                    'Cancel',
+                    style: AppTextStyles.button.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                ),
+              ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.md,
+            AppSizes.md,
+            AppSizes.md,
+            AppSizes.lg,
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/keystona/lib/features/documents/widgets/upload_category_step.dart
+++ b/apps/keystona/lib/features/documents/widgets/upload_category_step.dart
@@ -1,0 +1,313 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_sizes.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../models/document_category.dart';
+import '../models/document_type.dart';
+import '../providers/document_categories_provider.dart';
+import '../providers/document_types_provider.dart';
+import '../providers/document_upload_provider.dart';
+
+/// Step 1 of the upload wizard — category and optional document type selection.
+///
+/// Shows a scrollable list of [DocumentCategory] tiles. After selecting a
+/// category, document types for that category expand inline. Tapping a type
+/// (or tapping "Skip" on the type list) advances to step 2.
+class UploadCategoryStep extends ConsumerStatefulWidget {
+  const UploadCategoryStep({super.key, required this.onNext});
+
+  final VoidCallback onNext;
+
+  @override
+  ConsumerState<UploadCategoryStep> createState() =>
+      _UploadCategoryStepState();
+}
+
+class _UploadCategoryStepState extends ConsumerState<UploadCategoryStep> {
+  String? _expandedCategoryId;
+
+  @override
+  Widget build(BuildContext context) {
+    final categoriesAsync =
+        ref.watch(documentCategoriesProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Choose a category', style: AppTextStyles.h3),
+        const SizedBox(height: AppSizes.xs),
+        Text(
+          'What kind of document is this?',
+          style: AppTextStyles.bodyMedium.copyWith(
+            color: AppColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: AppSizes.lg),
+        Expanded(
+          child: categoriesAsync.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, st) => Center(
+              child: Text(
+                'Could not load categories.',
+                style: AppTextStyles.bodyMedium.copyWith(
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ),
+            data: (categories) => ListView.separated(
+              itemCount: categories.length,
+              separatorBuilder: (context, index) =>
+                  const SizedBox(height: AppSizes.xs),
+              itemBuilder: (context, i) => _CategoryTile(
+                category: categories[i],
+                isExpanded: _expandedCategoryId == categories[i].id,
+                onSelect: (cat) {
+                  setState(() {
+                    _expandedCategoryId =
+                        _expandedCategoryId == cat.id ? null : cat.id;
+                  });
+                  // Select category; document type will be picked from
+                  // the expanded sub-list or skipped.
+                  ref
+                      .read(documentUploadProvider.notifier)
+                      .selectCategory(cat.id);
+                },
+                onTypeSelected: (cat, type) {
+                  ref
+                      .read(documentUploadProvider.notifier)
+                      .selectCategory(cat.id, documentTypeId: type.id);
+                  ref
+                      .read(documentUploadProvider.notifier)
+                      .advanceToMetadata();
+                  widget.onNext();
+                },
+                onSkipType: (cat) {
+                  ref
+                      .read(documentUploadProvider.notifier)
+                      .selectCategory(cat.id);
+                  ref
+                      .read(documentUploadProvider.notifier)
+                      .advanceToMetadata();
+                  widget.onNext();
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Category tile ─────────────────────────────────────────────────────────────
+
+class _CategoryTile extends ConsumerWidget {
+  const _CategoryTile({
+    required this.category,
+    required this.isExpanded,
+    required this.onSelect,
+    required this.onTypeSelected,
+    required this.onSkipType,
+  });
+
+  final DocumentCategory category;
+  final bool isExpanded;
+  final ValueChanged<DocumentCategory> onSelect;
+  final void Function(DocumentCategory, DocumentType) onTypeSelected;
+  final ValueChanged<DocumentCategory> onSkipType;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final color = _parseColor(category.color);
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      alignment: Alignment.topCenter,
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: AppRadius.md,
+          border: Border.all(
+            color: isExpanded ? color : AppColors.border,
+            width: isExpanded ? 1.5 : 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            InkWell(
+              onTap: () => onSelect(category),
+              borderRadius: AppRadius.md,
+              child: Padding(
+                padding: AppPadding.card,
+                child: Row(
+                  children: [
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: color.withAlpha(30),
+                        borderRadius: AppRadius.sm,
+                      ),
+                      child: Icon(
+                        _categoryIcon(category.icon),
+                        color: color,
+                        size: AppSizes.iconMd,
+                      ),
+                    ),
+                    const SizedBox(width: AppSizes.md),
+                    Expanded(
+                      child: Text(
+                        category.name,
+                        style: AppTextStyles.bodyMediumSemibold,
+                      ),
+                    ),
+                    Icon(
+                      isExpanded
+                          ? Icons.keyboard_arrow_up
+                          : Icons.keyboard_arrow_down,
+                      color: AppColors.textSecondary,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (isExpanded) ...[
+              const Divider(height: 1, indent: AppSizes.md, endIndent: AppSizes.md),
+              _TypeList(
+                category: category,
+                onTypeSelected: onTypeSelected,
+                onSkip: onSkipType,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _parseColor(String hex) {
+    final sanitised = hex.replaceAll('#', '');
+    if (sanitised.length != 6) return AppColors.deepNavy;
+    final value = int.tryParse('FF$sanitised', radix: 16);
+    return value != null ? Color(value) : AppColors.deepNavy;
+  }
+
+  IconData _categoryIcon(String icon) {
+    switch (icon) {
+      case 'insurance':
+        return Icons.shield_outlined;
+      case 'warranty':
+        return Icons.workspace_premium_outlined;
+      case 'deed':
+        return Icons.home_work_outlined;
+      case 'tax':
+        return Icons.receipt_long_outlined;
+      case 'permit':
+        return Icons.approval_outlined;
+      case 'manual':
+        return Icons.menu_book_outlined;
+      case 'invoice':
+        return Icons.receipt_outlined;
+      case 'contract':
+        return Icons.handshake_outlined;
+      default:
+        return Icons.folder_outlined;
+    }
+  }
+}
+
+// ── Document type sub-list ────────────────────────────────────────────────────
+
+class _TypeList extends ConsumerWidget {
+  const _TypeList({
+    required this.category,
+    required this.onTypeSelected,
+    required this.onSkip,
+  });
+
+  final DocumentCategory category;
+  final void Function(DocumentCategory, DocumentType) onTypeSelected;
+  final ValueChanged<DocumentCategory> onSkip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final typesAsync = ref.watch(documentTypesProvider(category.id));
+
+    return typesAsync.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.all(AppSizes.md),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, st) => _SkipRow(onSkip: () => onSkip(category)),
+      data: (types) {
+        if (types.isEmpty) {
+          // No types for this category — advance immediately.
+          WidgetsBinding.instance.addPostFrameCallback(
+            (ts) => onSkip(category),
+          );
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ...types.map(
+              (type) => ListTile(
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.md,
+                  vertical: AppSizes.xs,
+                ),
+                title: Text(type.name, style: AppTextStyles.bodyMedium),
+                subtitle: type.description != null
+                    ? Text(
+                        type.description!,
+                        style: AppTextStyles.caption.copyWith(
+                          color: AppColors.textSecondary,
+                        ),
+                      )
+                    : null,
+                trailing: const Icon(
+                  Icons.arrow_forward_ios,
+                  size: 14,
+                  color: AppColors.textSecondary,
+                ),
+                onTap: () => onTypeSelected(category, type),
+              ),
+            ),
+            _SkipRow(onSkip: () => onSkip(category)),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _SkipRow extends StatelessWidget {
+  const _SkipRow({required this.onSkip});
+
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md,
+        AppSizes.xs,
+        AppSizes.md,
+        AppSizes.sm,
+      ),
+      child: TextButton(
+        onPressed: onSkip,
+        child: Text(
+          'Skip — just use category',
+          style: AppTextStyles.labelLarge.copyWith(
+            color: AppColors.textSecondary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/keystona/lib/features/documents/widgets/upload_metadata_step.dart
+++ b/apps/keystona/lib/features/documents/widgets/upload_metadata_step.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_sizes.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../providers/document_upload_provider.dart';
+
+/// Step 2 of the upload wizard — document name, expiration date, and notes.
+///
+/// The name field is pre-populated from the file's base name via
+/// [DocumentUploadState.suggestedName].
+class UploadMetadataStep extends ConsumerStatefulWidget {
+  const UploadMetadataStep({
+    super.key,
+    required this.onNext,
+    required this.onBack,
+  });
+
+  final VoidCallback onNext;
+  final VoidCallback onBack;
+
+  @override
+  ConsumerState<UploadMetadataStep> createState() =>
+      _UploadMetadataStepState();
+}
+
+class _UploadMetadataStepState extends ConsumerState<UploadMetadataStep> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _notesController;
+  DateTime? _expirationDate;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = ref.read(documentUploadProvider);
+    _nameController = TextEditingController(
+      text: state.name.isNotEmpty ? state.name : state.suggestedName,
+    );
+    _notesController = TextEditingController(text: state.notes ?? '');
+    _expirationDate = state.expirationDate;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Document details', style: AppTextStyles.h3),
+        const SizedBox(height: AppSizes.xs),
+        Text(
+          'Name this document and add optional details.',
+          style: AppTextStyles.bodyMedium
+              .copyWith(color: AppColors.textSecondary),
+        ),
+        const SizedBox(height: AppSizes.lg),
+        Expanded(
+          child: Form(
+            key: _formKey,
+            child: ListView(
+              children: [
+                // ── Name ─────────────────────────────────────────────────
+                Text('Document name', style: AppTextStyles.labelLarge),
+                const SizedBox(height: AppSizes.xs),
+                TextFormField(
+                  controller: _nameController,
+                  textCapitalization: TextCapitalization.sentences,
+                  maxLength: 120,
+                  decoration: const InputDecoration(
+                    hintText: 'e.g. Home Insurance Policy 2025',
+                    counterText: '',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter a document name';
+                    }
+                    if (value.trim().length > 120) {
+                      return 'Name must be 120 characters or fewer';
+                    }
+                    return null;
+                  },
+                  onChanged: (v) => ref
+                      .read(documentUploadProvider.notifier)
+                      .setName(v),
+                ),
+
+                const SizedBox(height: AppSizes.lg),
+
+                // ── Expiration date ───────────────────────────────────────
+                Text('Expiration date', style: AppTextStyles.labelLarge),
+                const SizedBox(height: AppSizes.xs),
+                Text(
+                  'Optional — for warranties, insurance, permits.',
+                  style: AppTextStyles.caption
+                      .copyWith(color: AppColors.textSecondary),
+                ),
+                const SizedBox(height: AppSizes.sm),
+                _ExpirationDateField(
+                  value: _expirationDate,
+                  onChanged: (date) {
+                    setState(() => _expirationDate = date);
+                    ref
+                        .read(documentUploadProvider.notifier)
+                        .setExpirationDate(date);
+                  },
+                ),
+
+                const SizedBox(height: AppSizes.lg),
+
+                // ── Notes ─────────────────────────────────────────────────
+                Text('Notes', style: AppTextStyles.labelLarge),
+                const SizedBox(height: AppSizes.xs),
+                Text(
+                  'Optional — any context you want to remember.',
+                  style: AppTextStyles.caption
+                      .copyWith(color: AppColors.textSecondary),
+                ),
+                const SizedBox(height: AppSizes.sm),
+                TextFormField(
+                  controller: _notesController,
+                  maxLines: 3,
+                  maxLength: 500,
+                  textCapitalization: TextCapitalization.sentences,
+                  decoration: const InputDecoration(
+                    hintText: 'Add any notes…',
+                    counterText: '',
+                  ),
+                  onChanged: (v) => ref
+                      .read(documentUploadProvider.notifier)
+                      .setNotes(v.trim().isEmpty ? null : v),
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        // ── Actions ───────────────────────────────────────────────────────
+        const SizedBox(height: AppSizes.md),
+        FilledButton(
+          onPressed: _submit,
+          style: FilledButton.styleFrom(
+            backgroundColor: AppColors.deepNavy,
+            minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+            ),
+          ),
+          child: Text(
+            'Upload',
+            style: AppTextStyles.button
+                .copyWith(color: AppColors.textInverse),
+          ),
+        ),
+        const SizedBox(height: AppSizes.sm),
+        TextButton(
+          onPressed: widget.onBack,
+          child: Text(
+            'Back',
+            style: AppTextStyles.button
+                .copyWith(color: AppColors.textSecondary),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _submit() {
+    if (_formKey.currentState?.validate() != true) return;
+    // Persist final values before upload starts.
+    final notifier =
+        ref.read(documentUploadProvider.notifier);
+    notifier.setName(_nameController.text.trim());
+    notifier.setNotes(
+      _notesController.text.trim().isEmpty
+          ? null
+          : _notesController.text.trim(),
+    );
+    notifier.setExpirationDate(_expirationDate);
+    widget.onNext();
+    notifier.upload();
+  }
+}
+
+// ── Expiration date field ─────────────────────────────────────────────────────
+
+class _ExpirationDateField extends StatelessWidget {
+  const _ExpirationDateField({
+    required this.value,
+    required this.onChanged,
+  });
+
+  final DateTime? value;
+  final ValueChanged<DateTime?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = value != null
+        ? DateFormat('MMM d, yyyy').format(value!)
+        : 'Select a date';
+
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            icon: const Icon(Icons.calendar_today_outlined, size: 18),
+            label: Text(
+              label,
+              style: AppTextStyles.bodyMedium.copyWith(
+                color: value != null
+                    ? AppColors.textPrimary
+                    : AppColors.textSecondary,
+              ),
+            ),
+            style: OutlinedButton.styleFrom(
+              alignment: Alignment.centerLeft,
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.md,
+                vertical: AppSizes.sm,
+              ),
+              side: const BorderSide(color: AppColors.border),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+              ),
+            ),
+            onPressed: () async {
+              final now = DateTime.now();
+              final picked = await showDatePicker(
+                context: context,
+                initialDate: value ?? now.add(const Duration(days: 365)),
+                firstDate: now,
+                lastDate: DateTime(now.year + 30),
+              );
+              if (picked != null) onChanged(picked);
+            },
+          ),
+        ),
+        if (value != null) ...[
+          const SizedBox(width: AppSizes.sm),
+          IconButton(
+            icon: const Icon(Icons.clear, color: AppColors.textSecondary),
+            onPressed: () => onChanged(null),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/apps/keystona/lib/features/documents/widgets/upload_progress_step.dart
+++ b/apps/keystona/lib/features/documents/widgets/upload_progress_step.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_sizes.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../core/widgets/upgrade_sheet.dart';
+import '../models/document_upload_state.dart';
+import '../providers/document_upload_provider.dart';
+
+/// Step 3 of the upload wizard — upload progress and completion.
+///
+/// Shows an animated linear progress bar while uploading. On success, shows
+/// a confirmation message. On error, shows the error with a retry button.
+class UploadProgressStep extends ConsumerStatefulWidget {
+  const UploadProgressStep({
+    super.key,
+    required this.onDone,
+    required this.onRetry,
+  });
+
+  /// Called after a successful upload. Typically pops the wizard.
+  final VoidCallback onDone;
+
+  /// Called when the user taps "Retry" on an error.
+  final VoidCallback onRetry;
+
+  @override
+  ConsumerState<UploadProgressStep> createState() =>
+      _UploadProgressStepState();
+}
+
+class _UploadProgressStepState extends ConsumerState<UploadProgressStep> {
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(documentUploadProvider);
+
+    if (state.step == DocumentUploadStep.success) {
+      return _SuccessView(
+        documentName: state.uploadedDocument?.name ?? state.name,
+        onDone: widget.onDone,
+      );
+    }
+
+    if (state.errorMessage != null) {
+      if (state.errorMessage == 'free_tier') {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          UpgradeSheet.show(
+            context,
+            feature: 'unlimited document storage',
+          );
+        });
+        return _ErrorView(
+          message:
+              'You\'ve reached the 25 document limit on the free plan.',
+          onRetry: null,
+        );
+      }
+
+      return _ErrorView(
+        message: state.errorMessage!,
+        onRetry: widget.onRetry,
+      );
+    }
+
+    // Uploading — show animated progress bar.
+    return _ProgressView(progress: state.uploadProgress);
+  }
+}
+
+// ── Progress view ──────────────────────────────────────────────────────────────
+
+class _ProgressView extends StatelessWidget {
+  const _ProgressView({required this.progress});
+
+  final double progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _AnimatedUploadIcon(),
+            const SizedBox(height: AppSizes.xl),
+            Text(
+              progress < 0.5 ? 'Preparing upload…' : 'Uploading…',
+              style: AppTextStyles.h3,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              'This may take a moment.',
+              style: AppTextStyles.bodyMedium
+                  .copyWith(color: AppColors.textSecondary),
+            ),
+            const SizedBox(height: AppSizes.xl),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              child: LinearProgressIndicator(
+                value: progress < 0.05 ? null : progress,
+                minHeight: 6,
+                backgroundColor: AppColors.gray200,
+                valueColor: const AlwaysStoppedAnimation(AppColors.deepNavy),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Success view ───────────────────────────────────────────────────────────────
+
+class _SuccessView extends StatelessWidget {
+  const _SuccessView({
+    required this.documentName,
+    required this.onDone,
+  });
+
+  final String documentName;
+  final VoidCallback onDone;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                color: AppColors.successLight,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.check_rounded,
+                color: AppColors.success,
+                size: AppSizes.iconLg,
+              ),
+            ),
+            const SizedBox(height: AppSizes.xl),
+            Text('Document saved!', style: AppTextStyles.h2),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              '"$documentName" has been added to your vault.',
+              style: AppTextStyles.bodyMedium
+                  .copyWith(color: AppColors.textSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSizes.xl),
+            FilledButton(
+              onPressed: onDone,
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.deepNavy,
+                minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+                ),
+              ),
+              child: Text(
+                'Done',
+                style: AppTextStyles.button
+                    .copyWith(color: AppColors.textInverse),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Error view ─────────────────────────────────────────────────────────────────
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                color: AppColors.errorLight,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.error_outline_rounded,
+                color: AppColors.error,
+                size: AppSizes.iconLg,
+              ),
+            ),
+            const SizedBox(height: AppSizes.xl),
+            Text('Upload failed', style: AppTextStyles.h3),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              message,
+              style: AppTextStyles.bodyMedium
+                  .copyWith(color: AppColors.textSecondary),
+              textAlign: TextAlign.center,
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: AppSizes.xl),
+              FilledButton(
+                onPressed: onRetry,
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.deepNavy,
+                  minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+                  ),
+                ),
+                child: Text(
+                  'Try Again',
+                  style: AppTextStyles.button
+                      .copyWith(color: AppColors.textInverse),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Animated upload icon ──────────────────────────────────────────────────────
+
+class _AnimatedUploadIcon extends StatefulWidget {
+  const _AnimatedUploadIcon();
+
+  @override
+  State<_AnimatedUploadIcon> createState() => _AnimatedUploadIconState();
+}
+
+class _AnimatedUploadIconState extends State<_AnimatedUploadIcon>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scaleAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat(reverse: true);
+    _scaleAnim = Tween<double>(begin: 0.9, end: 1.1).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: _scaleAnim,
+      child: Container(
+        width: 72,
+        height: 72,
+        decoration: const BoxDecoration(
+          color: AppColors.deepNavy,
+          shape: BoxShape.circle,
+        ),
+        child: const Icon(
+          Icons.upload_rounded,
+          color: Colors.white,
+          size: AppSizes.iconLg,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/keystona/lib/features/documents/widgets/upload_source_sheet.dart
+++ b/apps/keystona/lib/features/documents/widgets/upload_source_sheet.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_sizes.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../core/widgets/photo_picker.dart';
+import '../providers/document_upload_provider.dart';
+
+/// Adaptive bottom sheet for choosing a document source.
+///
+/// On iOS: [CupertinoActionSheet]. On Android: Material [ListTile] sheet.
+/// After the user picks a file, calls
+/// [DocumentUploadNotifier.setFile] and invokes [onFilePicked].
+abstract final class UploadSourceSheet {
+  static Future<void> show(
+    BuildContext context,
+    WidgetRef ref, {
+    required VoidCallback onFilePicked,
+  }) async {
+    if (Platform.isIOS) {
+      await _showCupertinoSheet(context, ref, onFilePicked: onFilePicked);
+    } else {
+      await _showMaterialSheet(context, ref, onFilePicked: onFilePicked);
+    }
+  }
+
+  static Future<void> _showCupertinoSheet(
+    BuildContext context,
+    WidgetRef ref, {
+    required VoidCallback onFilePicked,
+  }) async {
+    await showCupertinoModalPopup<void>(
+      context: context,
+      builder: (_) => CupertinoActionSheet(
+        title: const Text('Add Document'),
+        message: const Text('Choose a source'),
+        actions: [
+          CupertinoActionSheetAction(
+            onPressed: () async {
+              Navigator.of(context, rootNavigator: true).pop();
+              await _pickImage(context, ref, ImageSource.camera,
+                  onFilePicked: onFilePicked);
+            },
+            child: const Text('Camera'),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () async {
+              Navigator.of(context, rootNavigator: true).pop();
+              await _pickImage(context, ref, ImageSource.gallery,
+                  onFilePicked: onFilePicked);
+            },
+            child: const Text('Photo Library'),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () async {
+              Navigator.of(context, rootNavigator: true).pop();
+              await _pickFile(ref, onFilePicked: onFilePicked);
+            },
+            child: const Text('Files (PDF)'),
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          isDestructiveAction: true,
+          onPressed: () =>
+              Navigator.of(context, rootNavigator: true).pop(),
+          child: const Text('Cancel'),
+        ),
+      ),
+    );
+  }
+
+  static Future<void> _showMaterialSheet(
+    BuildContext context,
+    WidgetRef ref, {
+    required VoidCallback onFilePicked,
+  }) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppSizes.radiusLg),
+        ),
+      ),
+      builder: (sheetContext) => _MaterialSourceSheet(
+        onCamera: () async {
+          Navigator.of(sheetContext).pop();
+          await _pickImage(context, ref, ImageSource.camera,
+              onFilePicked: onFilePicked);
+        },
+        onGallery: () async {
+          Navigator.of(sheetContext).pop();
+          await _pickImage(context, ref, ImageSource.gallery,
+              onFilePicked: onFilePicked);
+        },
+        onFiles: () async {
+          Navigator.of(sheetContext).pop();
+          await _pickFile(ref, onFilePicked: onFilePicked);
+        },
+      ),
+    );
+  }
+
+  // ── Pickers ──────────────────────────────────────────────────────────────
+
+  static Future<void> _pickImage(
+    BuildContext context,
+    WidgetRef ref,
+    ImageSource source, {
+    required VoidCallback onFilePicked,
+  }) async {
+    final file = source == ImageSource.camera
+        ? await PhotoPicker.pickFromCamera()
+        : await PhotoPicker.pickFromGallery();
+
+    if (file == null) return;
+
+    final mime = _mimeFromPath(file.path);
+    final name = _nameFromPath(file.path);
+    ref
+        .read(documentUploadProvider.notifier)
+        .setFile(file, mime, name);
+    onFilePicked();
+  }
+
+  static Future<void> _pickFile(
+    WidgetRef ref, {
+    required VoidCallback onFilePicked,
+  }) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['pdf'],
+      withData: false,
+    );
+
+    final path = result?.files.firstOrNull?.path;
+    if (path == null) return;
+
+    final file = File(path);
+    ref
+        .read(documentUploadProvider.notifier)
+        .setFile(file, 'application/pdf', _nameFromPath(path));
+    onFilePicked();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  static String _mimeFromPath(String path) {
+    final ext = path.split('.').lastOrNull?.toLowerCase() ?? '';
+    switch (ext) {
+      case 'pdf':
+        return 'application/pdf';
+      case 'png':
+        return 'image/png';
+      case 'heic':
+      case 'heif':
+        return 'image/heic';
+      default:
+        return 'image/jpeg';
+    }
+  }
+
+  static String _nameFromPath(String path) {
+    final fileName = path.split('/').last;
+    final dotIndex = fileName.lastIndexOf('.');
+    return dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+  }
+}
+
+/// Material source selection sheet for Android.
+class _MaterialSourceSheet extends StatelessWidget {
+  const _MaterialSourceSheet({
+    required this.onCamera,
+    required this.onGallery,
+    required this.onFiles,
+  });
+
+  final VoidCallback onCamera;
+  final VoidCallback onGallery;
+  final VoidCallback onFiles;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md,
+        AppSizes.lg,
+        AppSizes.md,
+        AppSizes.xl,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Add Document',
+            style: AppTextStyles.h3,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSizes.md),
+          _Tile(
+            icon: Icons.camera_alt_outlined,
+            label: 'Camera',
+            onTap: onCamera,
+          ),
+          const Divider(height: 1),
+          _Tile(
+            icon: Icons.photo_library_outlined,
+            label: 'Photo Library',
+            onTap: onGallery,
+          ),
+          const Divider(height: 1),
+          _Tile(
+            icon: Icons.picture_as_pdf_outlined,
+            label: 'Files (PDF)',
+            onTap: onFiles,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Tile extends StatelessWidget {
+  const _Tile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, color: AppColors.deepNavy),
+      title: Text(label, style: AppTextStyles.bodyLarge),
+      onTap: onTap,
+    );
+  }
+}
+
+/// Re-exported so callers don't need an image_picker import.
+enum ImageSource { camera, gallery }


### PR DESCRIPTION
## Summary
- Three-step upload wizard: **Category → Metadata → Progress/Success**
- Adaptive source picker: Camera / Photo Library / Files (PDF) with `CupertinoActionSheet` on iOS, Material bottom sheet on Android
- HEIC→JPEG compression via `flutter_image_compress` for images over 2 MB
- Free-tier gate at 25 documents — shows existing `UpgradeSheet`
- Fire-and-forget OCR trigger via `process-document-ocr` Edge Function stub
- Document list invalidated automatically after successful upload

## Extension points for downstream issues
- **#22 (Document Detail)**: `DocumentsNotifier.getById()`, `updateDocument()`, `softDelete()` stubbed — implement in that issue
- **#23 (Search)**: `DocumentsNotifier.setSearchQuery()` stubbed — implement in that issue
- **#25 (Categories)**: `DocumentCategoriesNotifier.create()`, `updateCategory()`, `deleteCategory()` stubbed — implement in that issue
- **#26 (OCR Edge Function)**: `_triggerOcr()` in `DocumentUploadNotifier` calls `process-document-ocr` — wire the real Edge Function in that issue

## Files added
- `models/document_upload_state.dart` — Freezed wizard state + `DocumentUploadStep` enum
- `providers/document_types_provider.dart` — family provider for types by category
- `providers/document_upload_provider.dart` — upload notifier with free-tier gate, compression, storage upload, DB insert
- `screens/document_upload_screen.dart` — adaptive wizard screen
- `widgets/upload_source_sheet.dart` — adaptive source picker
- `widgets/upload_category_step.dart` — step 1: category + type selection
- `widgets/upload_metadata_step.dart` — step 2: name, expiration, notes
- `widgets/upload_progress_step.dart` — step 3: progress bar, success card, error+retry

## Test plan
- [ ] Tap + button on iOS — `CupertinoActionSheet` appears with Camera / Photo Library / Files
- [ ] Cancel source picker → wizard screen pops
- [ ] Pick an image → wizard shows category step with all 6 system categories
- [ ] Expand a category → document types appear inline
- [ ] Tap a type → advances to metadata step
- [ ] Name field pre-filled from file name; clears to empty on tap
- [ ] Submit without name → validation error shown
- [ ] Set expiration date → badge visible; clear button removes date
- [ ] Tap Upload → progress bar animates from 0→100%
- [ ] Upload completes → success card shows document name
- [ ] Tap Done → back to document list, new document appears at top
- [ ] Upload 26th document → UpgradeSheet shown, upload cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)